### PR TITLE
Revert export statement to maintain interface compatibility

### DIFF
--- a/packages/hdwallet-provider/src/index.ts
+++ b/packages/hdwallet-provider/src/index.ts
@@ -242,4 +242,4 @@ class HDWalletProvider {
   }
 }
 
-export default HDWalletProvider;
+export = HDWalletProvider;


### PR DESCRIPTION
Using `export default HDWalletProvider` will break the interface as users will then have to do something like `const HDWalletProvider = require("@truffle/hdwallet-provider").default;`.

This PR changes the main export statement back to the way it was so as not to change this.